### PR TITLE
Contact Filter Endpoint

### DIFF
--- a/cmd/staledesk/server.go
+++ b/cmd/staledesk/server.go
@@ -55,17 +55,30 @@ func NewServer() *gin.Engine {
 	router := gin.New()
 	router.SetTrustedProxies(nil)
 
+	contacts := controller.NewContactsController()
+
 	apiBase := router.Group(apiPathBase)
 	{
 		contactsGroup := apiBase.Group("contacts")
 		{
-			contacts := controller.NewContactsController()
-			contactsGroup.DELETE(fmt.Sprintf("/:%s", controller.ParamNameContactID), contacts.Delete)
+			// Requests ending in "contacts" or "contacts/"
+			contactsGroup.GET("", contacts.GetAll)
 			contactsGroup.GET("/", contacts.GetAll)
-			contactsGroup.GET("/autocomplete", contacts.Search)
-			contactsGroup.GET(fmt.Sprintf("/:%s", controller.ParamNameContactID), contacts.GetByID)
+			contactsGroup.POST("", contacts.Add)
 			contactsGroup.POST("/", contacts.Add)
+
+			// Requests ending in "contacts/autocomplete"
+			contactsGroup.GET("/autocomplete", contacts.Search)
+
+			// Requests ending in "contacts/ID_NUMBER"
+			contactsGroup.DELETE(fmt.Sprintf("/:%s", controller.ParamNameContactID), contacts.Delete)
+			contactsGroup.GET(fmt.Sprintf("/:%s", controller.ParamNameContactID), contacts.GetByID)
 			contactsGroup.PUT(fmt.Sprintf("/:%s", controller.ParamNameContactID), contacts.Update)
+		}
+
+		searchGroup := apiBase.Group("search")
+		{
+			searchGroup.GET("/contacts", contacts.Filter)
 		}
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -79,19 +79,22 @@ func (cd *Data) populateContacts() error {
 	}
 
 	for _, contact := range defaultContacts {
+		log.WithFields(log.Fields{
+			"contact.active":     contact.Active,
+			"contact.address":    contact.Address,
+			"contact.created_at": contact.CreatedAt,
+			"contact.email":      contact.Email,
+			"contact.id":         contact.ID,
+			"contact.language":   contact.Language,
+			"contact.mobile":     contact.Mobile,
+			"contact.name":       contact.Name,
+			"contact.people_id":  contact.PeopleID,
+			"contact.phone":      contact.Phone,
+			"contact.timezone":   contact.TimeZone,
+			"contact.twitter_id": contact.TwitterID,
+		}).Trace("populating default contact")
 		cd.Contacts[contact.ID] = contact
 	}
-	//for _, data := range cd.Raw.Get("data.contacts") {
-	//	var newContact models.Contact
-	//	log.Debugf("contact data: %s", data)
-	//	if err := json.Unmarshal([]byte(data), &newContact); err != nil {
-	//		log.WithFields(log.Fields{
-	//			"error": err.Error(),
-	//		}).Fatal("cannot read contacts from config file")
-	//		return ErrCannotPopulateContactsFromConfig
-	//	}
-	//	cd.Contacts[newContact.ID] = newContact
-	//}
 	return nil
 }
 

--- a/internal/controller/contacts.go
+++ b/internal/controller/contacts.go
@@ -32,8 +32,7 @@ func NewContactsController() *Contacts {
 }
 
 func (contControl *Contacts) GetAll(ctx *gin.Context) {
-	respCode := http.StatusOK
-	ctx.JSON(respCode, contControl.CurrentContacts)
+	ctx.JSON(http.StatusOK, contControl.CurrentContacts)
 }
 
 func (contControl *Contacts) GetByID(ctx *gin.Context) {

--- a/internal/controller/contacts.go
+++ b/internal/controller/contacts.go
@@ -39,7 +39,11 @@ func NewContactsController() *Contacts {
 }
 
 func (contControl *Contacts) GetAll(ctx *gin.Context) {
-	ctx.JSON(http.StatusOK, contControl.CurrentContacts)
+	var respContacts []models.Contact
+	for _, cont := range contControl.CurrentContacts {
+		respContacts = append(respContacts, cont)
+	}
+	ctx.JSON(http.StatusOK, respContacts)
 }
 
 func (contControl *Contacts) GetByID(ctx *gin.Context) {

--- a/internal/controller/contacts.go
+++ b/internal/controller/contacts.go
@@ -5,10 +5,12 @@ import (
 	"math/rand"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/SkyMack/staledesk/config"
 	"github.com/SkyMack/staledesk/internal/models"
 	"github.com/gin-gonic/gin"
+	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -23,6 +25,11 @@ var (
 
 type Contacts struct {
 	CurrentContacts map[int]models.Contact
+}
+
+type FilterContactsResp struct {
+	Total   int              `json:"total" mapstructure:"totle"`
+	Results []models.Contact `json:"results" mapstructure:"results"`
 }
 
 func NewContactsController() *Contacts {
@@ -51,6 +58,59 @@ func (contControl *Contacts) GetByID(ctx *gin.Context) {
 
 func (contControl *Contacts) Search(ctx *gin.Context) {
 
+}
+
+func (contControl *Contacts) Filter(ctx *gin.Context) {
+	queryStr := ctx.Query("query")
+	if len(queryStr) == 0 {
+		contControl.GetAll(ctx)
+	} else {
+		var matchingContacts []models.Contact
+		validValues := getValidValuesFromFilterQueryString(queryStr)
+		for _, cont := range contControl.CurrentContacts {
+			log.WithFields(log.Fields{
+				"contact.people_id": cont.PeopleID,
+			}).Debug("checking for matching people id")
+			if validValues[cont.PeopleID] {
+				log.Debug("match found")
+				matchingContacts = append(matchingContacts, cont)
+			}
+		}
+		resp := FilterContactsResp{
+			Total:   len(matchingContacts),
+			Results: matchingContacts,
+		}
+		ctx.JSON(http.StatusOK, resp)
+	}
+}
+
+// TODO: Make this more robust when required
+// Currently we expect to only filter by a specific field, with one or more statements separated by OR
+func getValidValuesFromFilterQueryString(query string) map[string]bool {
+	validValues := make(map[string]bool)
+	log.WithFields(log.Fields{
+		"query": query,
+	}).Debug("starting query string processing")
+	// Strip the surrounding double quotes form the query value\
+	query = strings.Trim(query, "\"")
+	// Divide up a *fieldName:fieldValue OR fieldName:fieldValue* query into separate statements
+	statements := strings.Split(query, " OR ")
+	for _, statement := range statements {
+		// Spit a *fieldName:fieldValue* statement into separate pieces
+		statementPieces := strings.Split(statement, ":")
+		// Add the fieldValue piece to the list of valid values, removing the single quotes if the value is in quotes
+		if len(statementPieces) > 1 {
+			trimmedValue := strings.Trim(statementPieces[1], "'")
+			if len(trimmedValue) > 0 {
+				validValues[trimmedValue] = true
+			}
+		}
+	}
+	log.WithFields(log.Fields{
+		"values.count": len(validValues),
+		"values":       validValues,
+	}).Debug("query string processed")
+	return validValues
 }
 
 func (contControl *Contacts) Add(ctx *gin.Context) {

--- a/internal/models/contacts.go
+++ b/internal/models/contacts.go
@@ -1,57 +1,54 @@
 package models
 
-import "time"
-
 // Contact contains the unmarshalled data for a "FreshDesk" contact
 type Contact struct {
-	Active         bool                `json:"active,omitempty"`
-	Address        string              `json:"address,omitempty"`
-	Avatar         ContactAvatar       `json:"avatar,omitempty"`
-	CompanyID      int                 `json:"company_id,omitempty"`
-	CreatedAt      time.Time           `json:"created_at,omitempty"`
-	CustomFields   ContactCustomFields `json:"custom_fields,omitempty"`
-	Deleted        bool                `json:"deleted,omitempty"`
-	Description    string              `json:"description,omitempty"`
-	Email          string              `json:"email,omitempty"`
-	ExternalID     string              `json:"external_id,omitempty"`
-	FacebookID     string              `json:"facebookID,omitempty"`
-	ID             int                 `json:"id,omitempty,omitempty"`
-	JobTitle       string              `json:"job_title,omitempty"`
-	Language       string              `json:"language,omitempty"`
-	Mobile         string              `json:"mobile,omitempty"`
-	Name           string              `json:"name,omitempty"`
+	Active         bool                `json:"active,omitempty" mapstructure:"active,omitempty"`
+	Address        string              `json:"address,omitempty" mapstructure:"address,omitempty"`
+	Avatar         ContactAvatar       `json:"avatar,omitempty" mapstructure:"avatar,omitempty"`
+	CompanyID      int                 `json:"company_id,omitempty" mapstructure:"company_id,omitempty"`
+	CreatedAt      string              `json:"created_at,omitempty" mapstructure:"created_at,omitempty"`
+	CustomFields   ContactCustomFields `json:"custom_fields,omitempty" mapstructure:"custom_fields,omitempty"`
+	Deleted        bool                `json:"deleted,omitempty" mapstructure:"deleted,omitempty"`
+	Description    string              `json:"description,omitempty" mapstructure:"description,omitempty"`
+	Email          string              `json:"email,omitempty" mapstructure:"email,omitempty"`
+	ExternalID     string              `json:"external_id,omitempty" mapstructure:"external_id,omitempty"`
+	ID             int                 `json:"id,omitempty,omitempty" mapstructure:"id,omitempty"`
+	JobTitle       string              `json:"job_title,omitempty" mapstructure:"job_title,omitempty"`
+	Language       string              `json:"language,omitempty" mapstructure:"language,omitempty"`
+	Mobile         string              `json:"mobile,omitempty" mapstructure:"mobile,omitempty"`
+	Name           string              `json:"name,omitempty" mapstructure:"name,omitempty"`
 	OtherCompanies []struct {
-		CompanyID      int  `json:"company_id"`
-		ViewAllTickets bool `json:"view_all_tickets"`
+		CompanyID      int  `json:"company_id" mapstructure:"company_id"`
+		ViewAllTickets bool `json:"view_all_tickets" mapstructure:"view_all_tickets"`
 	} `json:"other_companies,omitempty"`
-	OtherEmails    []string      `json:"other_emails,omitempty"`
-	PeopleID       string        `json:"unique_external_id,omitempty"`
-	Phone          string        `json:"phone,omitempty"`
-	Tags           []interface{} `json:"tags,omitempty"`
-	TimeZone       string        `json:"time_zone,omitempty"`
-	TwitterID      string        `json:"twitter_id,omitempty"`
-	UpdatedAt      time.Time     `json:"updated_at,omitempty"`
-	ViewAllTickets bool          `json:"view_all_tickets,omitempty"`
+	OtherEmails    []string      `json:"other_emails,omitempty" mapstructure:"other_emails,omitempty"`
+	PeopleID       string        `json:"unique_external_id,omitempty" mapstructure:"unique_external_id,omitempty"`
+	Phone          string        `json:"phone,omitempty" mapstructure:"phone,omitempty"`
+	Tags           []interface{} `json:"tags,omitempty" mapstructure:"tags,omitempty"`
+	TimeZone       string        `json:"time_zone,omitempty" mapstructure:"time_zone,omitempty"`
+	TwitterID      string        `json:"twitter_id,omitempty" mapstructure:"twitter_id,omitempty"`
+	UpdatedAt      string        `json:"updated_at,omitempty" mapstructure:"updated_at,omitempty"`
+	ViewAllTickets bool          `json:"view_all_tickets,omitempty" mapstructure:"view_all_tickets,omitempty"`
 }
 
 // ContactAvatar contains the subfields for the avatar field of the Contact type
 type ContactAvatar struct {
-	AvatarUrl   string     `json:"avatar_url,omitempty"`
-	ContentType string     `json:"content_type,omitempty"`
-	Id          int        `json:"id,omitempty"`
-	Name        string     `json:"name,omitempty"`
-	Size        int        `json:"size,omitempty"`
-	CreatedAt   *time.Time `json:"created_at,omitempty"`
-	UpdatedAt   *time.Time `json:"updated_at,omitempty"`
+	AvatarUrl   string `json:"avatar_url,omitempty" mapstructure:"avatar_url,omitempty"`
+	ContentType string `json:"content_type,omitempty" mapstructure:"content_type,omitempty"`
+	Id          int    `json:"id,omitempty" mapstructure:"id,omitempty"`
+	Name        string `json:"name,omitempty" mapstructure:"name,omitempty"`
+	Size        int    `json:"size,omitempty" mapstructure:"size,omitempty"`
+	CreatedAt   string `json:"created_at,omitempty" mapstructure:"created_at,omitempty"`
+	UpdatedAt   string `json:"updated_at,omitempty" mapstructure:"updated_at,omitempty"`
 }
 
 // ContactCustomFields contains the values for the custom_fields portion of a Contact
 type ContactCustomFields struct {
-	Benefit           string `json:"benefit,omitempty"`
-	DateOfBirth       string `json:"date_of_birth,omitempty"`
-	EligibilityStatus string `json:"eligibility_status,omitempty"`
-	LoginEmail        string `json:"login_email,omitempty"`
-	LoginPassword     string `json:"login_password,omitempty"`
-	Phone1            string `json:"phone_1,omitempty"`
-	Phone2            string `json:"phone_2,omitempty"`
+	Benefit           string `json:"benefit,omitempty" mapstructure:"benefit,omitempty"`
+	DateOfBirth       string `json:"date_of_birth,omitempty" mapstructure:"date_of_birth,omitempty"`
+	EligibilityStatus string `json:"eligibility_status,omitempty" mapstructure:"eligibility_status,omitempty"`
+	LoginEmail        string `json:"login_email,omitempty" mapstructure:"login_email,omitempty"`
+	LoginPassword     string `json:"login_password,omitempty" mapstructure:"login_password,omitempty"`
+	Phone1            string `json:"phone_1,omitempty" mapstructure:"phone_1,omitempty"`
+	Phone2            string `json:"phone_2,omitempty" mapstructure:"phone_2,omitempty"`
 }


### PR DESCRIPTION
Implements a rudimentary version of the the Filter Contact endpoint described here: https://developers.freshdesk.com/api/#filter_contacts

Currently all queries are expected to be OR queries against the value of the `unique_external_id` field, so that is the only thing we plan to use it for.

- Implement filter contact endpoint
- Add `mapstructure` tags to `models.Contact` for Viper compatibility
- Correct the response format for the List All Contacts endpoint
- Reorganize the route setup a bit